### PR TITLE
Surround passwords in config files with quotes.

### DIFF
--- a/templates/debian.cnf.j2
+++ b/templates/debian.cnf.j2
@@ -3,11 +3,11 @@
 [client]
 host     = localhost
 user     = debian-sys-maint
-password = {{mariadb_debsysmaint_password}}
+password = "{{mariadb_debsysmaint_password}}"
 socket   = /var/run/mysqld/mysqld.sock
 [mysql_upgrade]
 host     = localhost
 user     = debian-sys-maint
-password = {{mariadb_debsysmaint_password}}
+password = "{{mariadb_debsysmaint_password}}"
 socket   = /var/run/mysqld/mysqld.sock
 basedir  = /usr

--- a/templates/home_my.cnf.j2
+++ b/templates/home_my.cnf.j2
@@ -1,4 +1,4 @@
 [client]
 user={{ mariadb_root_username }}
-password={{ mariadb_root_password }}
+password="{{ mariadb_root_password }}"
 port={{ mariadb_client_port }}


### PR DESCRIPTION
Certain chars are problematic in passwords if not quoted (# for exmaple).
