### PR TITLE
Fixes [WARNING]: when statements should not include jinja2 templating…

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -7,4 +7,4 @@
     encoding: "{{ item.encoding | default('utf8') }}"
     state: present
   with_items: "{{mariadb_databases}}"
-  when: "{{mariadb_databases|length > 0}}"
+  when: "mariadb_databases|length > 0"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -8,4 +8,4 @@
     host: "{{item.host | default('localhost')}}"
     state: "{{item.state | default('present')}}"
   with_items: "{{mariadb_users}}"
-  when: "{{mariadb_users|length > 0}}"
+  when: "mariadb_users|length > 0"


### PR DESCRIPTION
… delimiters

When using Ansible 2.4