### PR TITLE
Include to import tasks

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   company: 
   description: MariaDB
   license: GPL
-  min_ansible_version: 1.6
+  min_ansible_version: 2.4
   platforms:
     - name: Debian
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
-- include: install.yml
+- import_tasks: install.yml
   tags: [mariadb]
-- include: configure.yml
+- import_tasks: configure.yml
   tags: [mariadb]
-- include: databases.yml
+- import_tasks: databases.yml
   tags: [mariadb]
-- include: users.yml
+- import_tasks: users.yml
   tags: [mariadb]


### PR DESCRIPTION
Maybe you don't want to merge this just yet, since the minimum Ansible version is 2.4, but this fixes deprecation warnings for me.

And I try to keep using always the newest Ansible version from git.